### PR TITLE
Ensure that we never use cached results,…

### DIFF
--- a/Hyperconnectivity/Classes/Core/Hyperconnectivity.swift
+++ b/Hyperconnectivity/Classes/Core/Hyperconnectivity.swift
@@ -57,8 +57,13 @@ public class Hyperconnectivity {
 
 private extension Hyperconnectivity {
     private func checkConnectivity(of path: NWPath, using configuration: Configuration) {
+        // Ensure that we never use cached results, including with custom `URLSessionConfiguration`s.
+        let urlSessionConfiguration = configuration.urlSessionConfiguration.copy() as! URLSessionConfiguration
+        urlSessionConfiguration.requestCachePolicy = .reloadIgnoringCacheData
+        urlSessionConfiguration.urlCache = nil
+        
         let publishers = configuration.connectivityURLs.map { url in
-            URLSession(configuration: configuration.urlSessionConfiguration).dataTaskPublisher(for: url)
+            URLSession(configuration: urlSessionConfiguration).dataTaskPublisher(for: url)
         }
         let totalChecks = UInt(configuration.connectivityURLs.count)
         let result = ConnectivityResult(path: path, successThreshold: configuration.successThreshold, totalChecks: totalChecks)

--- a/Hyperconnectivity/Classes/Model/Configuration.swift
+++ b/Hyperconnectivity/Classes/Model/Configuration.swift
@@ -16,6 +16,7 @@ public struct HyperconnectivityConfiguration {
     public static let defaultURLSessionConfiguration: URLSessionConfiguration = {
         let sessionConfiguration = URLSessionConfiguration.default
         sessionConfiguration.requestCachePolicy = .reloadIgnoringCacheData
+        sessionConfiguration.urlCache = nil
         sessionConfiguration.timeoutIntervalForRequest = 5.0
         sessionConfiguration.timeoutIntervalForResource = 5.0
         return sessionConfiguration


### PR DESCRIPTION
...including with custom `URLSessionConfiguration`s.