### PR TITLE
Add ConnectivityLink

### DIFF
--- a/Example/Hyperconnectivity.xcodeproj/project.pbxproj
+++ b/Example/Hyperconnectivity.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		13962F252471B48700CCE8B9 /* failure-response.html in Resources */ = {isa = PBXBuildFile; fileRef = 13962F242471B48700CCE8B9 /* failure-response.html */; };
 		13C3D88F2471C36800E0A879 /* ReachabilityPublisherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C3D88E2471C36800E0A879 /* ReachabilityPublisherTests.swift */; };
 		13EDCA922465DDFB006FAE75 /* UIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13EDCA912465DDFB006FAE75 /* UIColor.swift */; };
+		397063A028F8163200A270BD /* ConnectivityLinkTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3970639F28F8163200A270BD /* ConnectivityLinkTests.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
@@ -60,6 +61,7 @@
 		13962F242471B48700CCE8B9 /* failure-response.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = "failure-response.html"; sourceTree = "<group>"; };
 		13C3D88E2471C36800E0A879 /* ReachabilityPublisherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReachabilityPublisherTests.swift; sourceTree = "<group>"; };
 		13EDCA912465DDFB006FAE75 /* UIColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColor.swift; sourceTree = "<group>"; };
+		3970639F28F8163200A270BD /* ConnectivityLinkTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityLinkTests.swift; sourceTree = "<group>"; };
 		3CA628B2EBED9449AB582CF5 /* Pods-Hyperconnectivity_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Hyperconnectivity_Tests.release.xcconfig"; path = "Target Support Files/Pods-Hyperconnectivity_Tests/Pods-Hyperconnectivity_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		5906C1669FAA2FD5D578F683 /* Pods_Hyperconnectivity_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Hyperconnectivity_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5DAEB079CF13776E26B7C9D7 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
@@ -179,6 +181,7 @@
 				13962F102471919F00CCE8B9 /* Mocks */,
 				13962F212471A95F00CCE8B9 /* Response Validation Tests */,
 				134B21BF2468779E00A8F332 /* ConnectionTests.swift */,
+				3970639F28F8163200A270BD /* ConnectivityLinkTests.swift */,
 				134B21BC2466DC7200A8F332 /* ConnectivityStateTests.swift */,
 				607FACEB1AFB9204008FA782 /* PercentageTests.swift */,
 				13962F09246F3F7300CCE8B9 /* ConnectivitySubscriptionTests.swift */,
@@ -435,6 +438,7 @@
 				13962F0A246F3F7300CCE8B9 /* ConnectivitySubscriptionTests.swift in Sources */,
 				13962F1A247196F800CCE8B9 /* ResponseContainsStringValidatorTests.swift in Sources */,
 				13962F18247196AE00CCE8B9 /* ResponseStringEqualityValidatorTests.swift in Sources */,
+				397063A028F8163200A270BD /* ConnectivityLinkTests.swift in Sources */,
 				13C3D88F2471C36800E0A879 /* ReachabilityPublisherTests.swift in Sources */,
 				13962F162471968300CCE8B9 /* ResponseRegExValidatorTests.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* PercentageTests.swift in Sources */,

--- a/Example/Tests/ConnectivityLinkTests.swift
+++ b/Example/Tests/ConnectivityLinkTests.swift
@@ -1,0 +1,37 @@
+//
+//  ConnectivityLinkTests.swift
+//  Hyperconnectivity_Tests
+//
+//  Created by Bruno Miguens on 13/10/2022.
+//  Copyright © 2022 Bruno Miguens. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import Hyperconnectivity
+
+class ConnectivityLinkTests: XCTestCase {
+    
+    func testIfUrlConstructsDataTaskPublisher() {
+        let url = URL(string: "https://github.com")!
+        let sut = URLSession(configuration: .default).dataTaskPublisher(for: ConnectivityLink.url(url))
+        XCTAssertEqual(sut.request.url, url)
+    }
+    
+    func testIfUrRequestlConstructsDataTaskPublisher() {
+        let urlRequest = URLRequest(url: URL(string: "https://github.com")!)
+        let sut = URLSession(configuration: .default).dataTaskPublisher(for: ConnectivityLink.request(urlRequest))
+        XCTAssertEqual(sut.request, urlRequest)
+    }
+    
+    func testIfUrRequestlConstructsDataTaskPublisherWithCustomData() {
+        var urlRequest = URLRequest(url: URL(string: "https://github.com")!)
+        urlRequest.setValue("Value", forHTTPHeaderField: "Field")
+        urlRequest.httpMethod = "POST"
+        urlRequest.httpBody = Data()
+        
+        let sut = URLSession(configuration: .default).dataTaskPublisher(for: ConnectivityLink.request(urlRequest))
+        XCTAssertEqual(sut.request, urlRequest)
+    }
+
+}

--- a/Hyperconnectivity/Classes/Core/Hyperconnectivity.swift
+++ b/Hyperconnectivity/Classes/Core/Hyperconnectivity.swift
@@ -53,10 +53,10 @@ private extension Hyperconnectivity {
     private func checkConnectivity(of path: NWPath, using configuration: Configuration) {
         let factory = NonCachingURLSessionConfigurationFactory()
         let urlSessionConfiguration = factory.urlSessionConfiguration(from: configuration.urlSessionConfiguration)
-        let publishers = configuration.connectivityURLs.map { url in
-            URLSession(configuration: urlSessionConfiguration).dataTaskPublisher(for: url)
+        let publishers = configuration.connectivityLinks.map { link in
+            URLSession(configuration: urlSessionConfiguration).dataTaskPublisher(for: link)
         }
-        let totalChecks = UInt(configuration.connectivityURLs.count)
+        let totalChecks = UInt(configuration.connectivityLinks.count)
         let result = ConnectivityResult(path: path, successThreshold: configuration.successThreshold, totalChecks: totalChecks)
         let combinedPublisher = Publishers.MergeMany(publishers)
         cancellable = combinedPublisher.sink(receiveCompletion:{ [weak self] _ in

--- a/Hyperconnectivity/Classes/Model/Configuration.swift
+++ b/Hyperconnectivity/Classes/Model/Configuration.swift
@@ -8,11 +8,13 @@
 import Foundation
 
 public struct HyperconnectivityConfiguration {
-    public static let defaultConnectivityURLs = [
+    public static let defaultConnectivityLinks: [ConnectivityLink] = [
         URL(string: "https://www.apple.com/library/test/success.html"),
         URL(string: "https://captive.apple.com/hotspot-detect.html")
-        ]
-        .compactMap { $0 }
+    ].compactMap { url in
+        guard let url = url else { return nil }
+        return .url(url)
+    }
     public static let defaultURLSessionConfiguration: URLSessionConfiguration = {
         let sessionConfiguration = URLSessionConfiguration.default
         sessionConfiguration.requestCachePolicy = .reloadIgnoringCacheData
@@ -24,7 +26,7 @@ public struct HyperconnectivityConfiguration {
     
     let callbackQueue: DispatchQueue
     let connectivityQueue: DispatchQueue
-    let connectivityURLs: [URL]
+    let connectivityLinks: [ConnectivityLink]
     let responseValidator: ResponseValidator
     let shouldCheckConnectivity: Bool
     
@@ -34,7 +36,7 @@ public struct HyperconnectivityConfiguration {
     
     public init(callbackQueue: DispatchQueue = DispatchQueue.main,
                 connectivityQueue: DispatchQueue = DispatchQueue.global(qos: .utility),
-                connectivityURLs: [URL] = Self.defaultConnectivityURLs,
+                connectivityLinks: [ConnectivityLink] = Self.defaultConnectivityLinks,
                 responseValidator: ResponseValidator? = nil,
                 shouldCheckConnectivity: Bool = true,
                 successThreshold: Percentage = Percentage(50.0),
@@ -45,7 +47,7 @@ public struct HyperconnectivityConfiguration {
         )
         self.callbackQueue = callbackQueue
         self.connectivityQueue = connectivityQueue
-        self.connectivityURLs = connectivityURLs
+        self.connectivityLinks = connectivityLinks
         self.responseValidator = responseValidator ?? defaultValidator
         self.shouldCheckConnectivity = shouldCheckConnectivity
         self.successThreshold = successThreshold
@@ -56,7 +58,7 @@ public struct HyperconnectivityConfiguration {
         return HyperconnectivityConfiguration(
             callbackQueue: callbackQueue,
             connectivityQueue: connectivityQueue,
-            connectivityURLs: [],
+            connectivityLinks: [],
             responseValidator: responseValidator,
             shouldCheckConnectivity: false,
             successThreshold: Percentage(0.0),

--- a/Hyperconnectivity/Classes/Model/ConnectivityLink.swift
+++ b/Hyperconnectivity/Classes/Model/ConnectivityLink.swift
@@ -2,7 +2,7 @@
 //  ConnectivityLink.swift
 //  Hyperconnectivity
 //
-//  Created by Bruno Miguns on 13/10/2022.
+//  Created by Bruno Miguens on 13/10/2022.
 //
 
 import Foundation

--- a/Hyperconnectivity/Classes/Model/ConnectivityLink.swift
+++ b/Hyperconnectivity/Classes/Model/ConnectivityLink.swift
@@ -1,0 +1,24 @@
+//
+//  ConnectivityLink.swift
+//  Hyperconnectivity
+//
+//  Created by Bruno Miguns on 13/10/2022.
+//
+
+import Foundation
+
+public enum ConnectivityLink {
+    case url(URL)
+    case request(URLRequest)
+}
+
+extension URLSession {
+    func dataTaskPublisher(for link: ConnectivityLink) -> URLSession.DataTaskPublisher {
+        switch link {
+        case .url(let url):
+            return dataTaskPublisher(for: url)
+        case .request(let urlRequest):
+            return dataTaskPublisher(for: urlRequest)
+        }
+    }
+}


### PR DESCRIPTION
This PR aims to provide a more granular and personalised way to use connectivity links. 

Previously we could only use `URL` objects, which creates various issues if someone needs to do a POS, add headers or any other additional information allowed by the `URLRequest` object.

Instead of passing an array of `URL`, we will send an array of `ConnectivityLink` where we can choose between an `URLRequest` and `URL`. It should not change the implementations substantially but still provide a ruled way to use the library.

Feel free to comment, suggest any improvements or even close the PR.

Fixes #10 

